### PR TITLE
Fix version conflicts caused by PR#287

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -13,8 +13,8 @@
     <PackageReference Update="Xamarin.Forms.Mocks" Version="4.7.0.1" />
     <PackageReference Update="Xamarin.Essentials" Version="1.6.1" />
     <PackageReference Update="Xamarin.Essentials.Interfaces" Version="1.6.1" />
-    <PackageReference Update="Xamarin.AndroidX.MediaRouter" Version="1.2.4" />
-    <PackageReference Update="Xamarin.AndroidX.Palette" Version="1.0.0.7" />
+    <PackageReference Update="Xamarin.AndroidX.MediaRouter" Version="1.2.4.1" />
+    <PackageReference Update="Xamarin.AndroidX.Palette" Version="1.0.0.8" />
 
     <!-- General Dependencies -->
     <PackageReference Update="AvantiPoint.MobileToolkit.Forms.Fonts" Version="4.0.76" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Xamarin.AndroidX.MediaRouter from 1.2.4 to 1.2.4.1. [(PR#287)](https://github.com/AvantiPoint/AP.MobileToolkit/pull/287).
Hope this fix can help you.

Best regards,
sucrose